### PR TITLE
Locale fixes

### DIFF
--- a/__resource.lua
+++ b/__resource.lua
@@ -7,14 +7,20 @@ version '1.0.0'
 server_scripts {
 	'@mysql-async/lib/MySQL.lua',
 	'@es_extended/locale.lua',
+	'locales/br.lua',
 	'locales/de.lua',
+	'locales/en.lua',
+	'locales/tr.lua',
 	'config.lua',
 	'server/main.lua'
 }
 
 client_scripts {
 	'@es_extended/locale.lua',
+	'locales/br.lua',
 	'locales/de.lua',
+	'locales/en.lua',
+	'locales/tr.lua',
 	'config.lua',
 	'client/main.lua'
 }

--- a/locales/tr.lua
+++ b/locales/tr.lua
@@ -1,4 +1,4 @@
-Locales ['en'] = {
+Locales ['tr'] = {
   ['writingcontract'] = '%s plakası için kontrat yazılıyor.',
   ['soldvehicle'] = 'Aracı sicil numarasıyla sattınız. ~r~%s~s~',
   ['boughtvehicle'] = 'Aracı sicil numarasıyla satın aldınız. ~g~%s~s~',


### PR DESCRIPTION
Locale string for TR was set to EN, causing string overwrite.

Also load all locale tables in resource to allow configuration to work properly.